### PR TITLE
Add Warden gear item variants

### DIFF
--- a/WardenGear/wardenGear.xml
+++ b/WardenGear/wardenGear.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" ?>
+<items>
+    <item name="gunBotT3JunkDroneWarden" extends="gunBotT3JunkDrone">
+        <effect_group name="gunBotT3JunkDroneWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunBowT3CompoundBowWarden" extends="gunBowT3CompoundBow">
+        <effect_group name="gunBowT3CompoundBowWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunBowT3CompoundCrossbowWarden" extends="gunBowT3CompoundCrossbow">
+        <effect_group name="gunBowT3CompoundCrossbowWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunExplosivesT3RocketLauncherWarden" extends="gunExplosivesT3RocketLauncher">
+        <effect_group name="gunExplosivesT3RocketLauncherWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunHandgunT3DesertVultureWarden" extends="gunHandgunT3DesertVulture">
+        <effect_group name="gunHandgunT3DesertVultureWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunHandgunT3SMG5Warden" extends="gunHandgunT3SMG5">
+        <effect_group name="gunHandgunT3SMG5Warden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunMGT3M60Warden" extends="gunMGT3M60">
+        <effect_group name="gunMGT3M60Warden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunRifleT3SniperRifleWarden" extends="gunRifleT3SniperRifle">
+        <effect_group name="gunRifleT3SniperRifleWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="gunShotgunT3AutoShotgunWarden" extends="gunShotgunT3AutoShotgun">
+        <effect_group name="gunShotgunT3AutoShotgunWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeToolAxeT3ChainsawWarden" extends="meleeToolAxeT3Chainsaw">
+        <effect_group name="meleeToolAxeT3ChainsawWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeToolFarmT1IronHoeWarden" extends="meleeToolFarmT1IronHoe">
+        <effect_group name="meleeToolFarmT1IronHoeWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeToolPickT3AugerWarden" extends="meleeToolPickT3Auger">
+        <effect_group name="meleeToolPickT3AugerWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeToolRepairT3NailgunWarden" extends="meleeToolRepairT3Nailgun">
+        <effect_group name="meleeToolRepairT3NailgunWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeToolSalvageT3ImpactDriverWarden" extends="meleeToolSalvageT3ImpactDriver">
+        <effect_group name="meleeToolSalvageT3ImpactDriverWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeToolShovelT2SteelShovelWarden" extends="meleeToolShovelT2SteelShovel">
+        <effect_group name="meleeToolShovelT2SteelShovelWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeWpnBatonT2StunBatonWarden" extends="meleeWpnBatonT2StunBaton">
+        <effect_group name="meleeWpnBatonT2StunBatonWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeWpnBladeT3MacheteWarden" extends="meleeWpnBladeT3Machete">
+        <effect_group name="meleeWpnBladeT3MacheteWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeWpnClubT3SteelClubWarden" extends="meleeWpnClubT3SteelClub">
+        <effect_group name="meleeWpnClubT3SteelClubWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeWpnKnucklesT3SteelKnucklesWarden" extends="meleeWpnKnucklesT3SteelKnuckles">
+        <effect_group name="meleeWpnKnucklesT3SteelKnucklesWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeWpnSledgeT3SteelSledgehammerWarden" extends="meleeWpnSledgeT3SteelSledgehammer">
+        <effect_group name="meleeWpnSledgeT3SteelSledgehammerWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+    <item name="meleeWpnSpearT3SteelSpearWarden" extends="meleeWpnSpearT3SteelSpear">
+        <effect_group name="meleeWpnSpearT3SteelSpearWarden">
+            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
+            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
+            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+        </effect_group>
+        <property name="ModSlots" value="6"/>
+        <property name="CreativeMode" value="None"/>
+        <property name="CustomIconTint" value="FFD700"/>
+    </item>
+</items>


### PR DESCRIPTION
## Summary
- add WardenGear/wardenGear.xml with Warden variants for top-tier tools and weapons
- each variant extends its base item and adds stronger passive effects, six mod slots, and a gold icon tint

## Testing
- `xmllint --noout WardenGear/wardenGear.xml`


------
https://chatgpt.com/codex/tasks/task_e_68919178cc1c832680b6f7ca1258fb75