### PR TITLE
Boost resource yield for Warden harvesting tools

### DIFF
--- a/WardenGear/wardenGear.xml
+++ b/WardenGear/wardenGear.xml
@@ -105,6 +105,7 @@
             <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
             <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
             <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
         </effect_group>
         <property name="ModSlots" value="6"/>
         <property name="CreativeMode" value="Player"/>
@@ -116,6 +117,7 @@
             <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
             <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
             <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
         </effect_group>
         <property name="ModSlots" value="6"/>
         <property name="CreativeMode" value="Player"/>
@@ -127,6 +129,7 @@
             <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
             <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
             <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
         </effect_group>
         <property name="ModSlots" value="6"/>
         <property name="CreativeMode" value="Player"/>
@@ -149,6 +152,7 @@
             <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
             <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
             <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
         </effect_group>
         <property name="ModSlots" value="6"/>
         <property name="CreativeMode" value="Player"/>
@@ -160,6 +164,7 @@
             <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
             <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
             <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
         </effect_group>
         <property name="ModSlots" value="6"/>
         <property name="CreativeMode" value="Player"/>
@@ -182,6 +187,7 @@
             <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
             <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
             <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
+            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
         </effect_group>
         <property name="ModSlots" value="6"/>
         <property name="CreativeMode" value="Player"/>


### PR DESCRIPTION
## Summary
- give Warden chainsaw, hoe, auger, impact driver, shovel, and machete a 50% harvest bonus

## Testing
- `xmllint --noout WardenGear/wardenGear.xml`


------
https://chatgpt.com/codex/tasks/task_e_68919557c55c83268509cc26639974a5