### PR TITLE
Fix XML patch structure for Warden items

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" ?>
-<items>
+<?xml version="1.0" encoding="UTF-8"?>
+<configs>
+    <append xpath="/items">
     <item name="gunBotT3JunkDroneWarden" extends="gunBotT3JunkDrone">
         <effect_group name="gunBotT3JunkDroneWarden">
             <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
@@ -278,4 +279,5 @@
         <property name="CreativeMode" value="Player"/>
         <property name="CustomIconTint" value="FFD700"/>
     </item>
-</items>
+    </append>
+</configs>


### PR DESCRIPTION
## Summary
- wrap item definitions in `<configs>` root
- add `<append xpath="/items">` for new items

## Testing
- `xmllint --noout Config/items.xml`
- `xmllint --noout Config/wardenStacks.xml`
- `xmllint --noout ModInfo.xml`


------
https://chatgpt.com/codex/tasks/task_e_68919f4727608326af3b9f8771eace86