### PR TITLE
Inline base item properties for Warden items

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -1,282 +1,1858 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <configs>
-    <append xpath="/items">
-    <item name="gunBotT3JunkDroneWarden" extends="gunBotT3JunkDrone" material="Mmetal">
-        <effect_group name="gunBotT3JunkDroneWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+  <append xpath="/items">
+    <item name="gunBotT3JunkDroneWarden" material="Mmetal">
+      <property name="Tags" value="drone,turret,weapon,ranged,reloadPenalty,drumMagazine,attIntellect,perkTurrets,canHaveCosmetic" />
+      <property name="DisplayType" value="droneTurret" />
+      <property name="Group" value="Ammo/Weapons,Robotics" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/Junk Drone/junkDroneHeld_Prefab.prefab" />
+      <property name="HoldType" value="78" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="SoundDestroy" value="wooddestroy1" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <property name="EconomicBundleSize" value="1" />
+      <property name="EconomicValue" value="700" />
+      <property name="UnlockedBy" value="gunBotT3JunkDroneSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="TintColor" value="255,167,0" />
+      <property class="Action1">
+        <property name="Class" value="SpawnTurret" />
+        <property name="Turret" value="entityJunkDrone" />
+        <property name="PreviewSize" value="0.25,0.25,0.25" />
+      </property>
+      <effect_group name="gunBotT3JunkDrone">
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkTurrets" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkTurrets" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkTurrets" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkTurrets" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkTurrets" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="0" tags="perkTurrets" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="0" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierAiming" operation="perc_add" value="0" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="perc_add" value="0" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierWalking" operation="perc_add" value="0" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierRunning" operation="perc_add" value="0" tags="perkTurrets" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.1,.1" tags="perkTurrets" />
+        <passive_effect name="MagazineSize" operation="perc_add" value="-.122,.122" tags="perkTurrets" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkTurrets" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="60" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkTurrets" />
+        <passive_effect name="MagazineSize" operation="base_set" value="62" tags="perkTurrets" />
+        <passive_effect name="MagazineSize" operation="base_add" value="6,30" tier="2,6" tags="perkTurrets" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierAiming" operation="perc_add" value="-.13" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="perc_add" value="-.05" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierWalking" operation="perc_add" value=".15" tags="perkTurrets" />
+        <passive_effect name="SpreadMultiplierRunning" operation="perc_add" value=".3" tags="perkTurrets" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="3" tags="perkTurrets" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="3" tags="perkTurrets" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-2" tags="perkTurrets" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value="2" tags="perkTurrets" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="0" tags="perkTurrets" />
+        <passive_effect name="WeaponHandling" operation="base_set" value="1" tags="perkTurrets" />
+        <passive_effect name="DegradationMax" operation="base_set" value="250,600" tier="1,6" tags="perkTurrets" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="0.35" tags="perkTurrets" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+      </effect_group>
+      <effect_group name="gunBotT3JunkDroneWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunBowT3CompoundBowWarden" extends="gunBowT3CompoundBow" material="Mmetal">
-        <effect_group name="gunBowT3CompoundBowWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunBowT3CompoundBowWarden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,bowDrawPenalty,archery,bow,attAgility,perkArchery,canHaveCosmetic" />
+      <property name="DisplayType" value="rangedBow" />
+      <property name="HoldType" value="53" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/Bows/advancedBow/advancedCompoundBow/advancedCompoundBowPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="ItemNeedsRepair" />
+      <property name="SoundDestroy" value="wooddestroy1" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="false" />
+      <property name="EconomicBundleSize" value="1" />
+      <property name="EconomicValue" value="1000" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <property name="PickupJournalEntry" value="alternateAmmoTip" />
+      <property name="UnlockedBy" value="gunBowT3CompoundBowSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Catapult" />
+        <property name="Hitmask_override" value="Arrow" />
+        <property name="Delay" value="1" />
+        <property name="Magazine_items" value="ammoArrowStone,ammoArrowIron,ammoArrowSteelAP,ammoArrowFlaming,ammoArrowExploding" />
+        <property name="Sound_start" value="bow3_fire" />
+        <property name="Sound_repeat" value="" />
+        <property name="Sound_end" value="" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="Sound_reload" value="bow_unquiver" />
+        <property name="Sound_draw" value="bow3_draw" />
+        <property name="Sound_cancel" value="bow_fire_cancel" />
+        <property name="Particles_muzzle_fire" value="nozzleflashuzi" />
+        <property name="Particles_muzzle_smoke" value="nozzlesmokeuzi" />
+        <property name="Max_strain_time" value=".43" />
+        <requirement name="CVarCompare" cvar="_underwater" operation="LT" value=".98" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="40" />
+        <property name="Zoom_max_in" value="40" />
+      </property>
+      <effect_group name="gunBowT3CompoundBow">
+        <passive_effect name="ProjectileVelocity" operation="perc_add" value=".2" tags="perkArchery" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="30" tags="perkArchery" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkArchery" />
+        <passive_effect name="EntityDamage" operation="base_add" value="9.15" tags="perkArchery" />
+        <passive_effect name="MaxRange" operation="base_set" value="100" tags="perkArchery" />
+        <passive_effect name="MagazineSize" operation="base_set" value="1" tags="perkArchery" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkArchery" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkArchery" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkArchery" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkArchery" />
+        <passive_effect name="ProjectileVelocity" operation="perc_add" value="-.08,.08" tags="perkArchery" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkArchery" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkArchery" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="2.67" tags="perkArchery" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="2.67" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".15" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2.2" tags="perkArchery" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value=".9" tags="perkArchery" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="2" tags="perkArchery" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".9" tags="perkArchery" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="75" tags="perkArchery,bowDrawPenalty" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkArchery" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value=".5" tags="perkArchery" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value=".5" tags="perkArchery" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.2" tags="perkArchery" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".2" tags="perkArchery" />
+        <passive_effect name="DegradationMax" operation="base_set" value="200,400" tier="1,6" tags="perkArchery" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkArchery" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+      </effect_group>
+      <effect_group name="sneak damage bonus">
+        <requirement name="CVarCompare" cvar="_crouching" operation="Equals" value="1" />
+        <requirement name="CVarCompare" cvar="_notAlerted" operation="GT" value="0" target="other" />
+        <passive_effect name="DamageBonus" operation="base_add" value="2" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="2" tags="perkArchery" />
+        <display_value name="dEntityDamageSneak" value="2" />
+      </effect_group>
+      <effect_group name="gunBowT3CompoundBowWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunBowT3CompoundCrossbowWarden" extends="gunBowT3CompoundCrossbow" material="Mmetal">
-        <effect_group name="gunBowT3CompoundCrossbowWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunBowT3CompoundCrossbowWarden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,holdBreathAiming,reloadPenalty,sideAttachments,smallTopAttachments,mediumTopAttachments,bottomAttachments,attAgility,perkArchery,crossbow,attachmentsIncluded,canHaveCosmetic" />
+      <property name="DisplayType" value="rangedBow" />
+      <property name="DescriptionKey" value="gunBowT1IronCrossbowDesc" />
+      <property name="HoldType" value="69" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/Bows/AdvancedBow/AdvancedCompoundCrossbow/AdvancedCompoundCrossbowPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="EconomicValue" value="1000" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="ItemNeedsRepair" />
+      <property name="SoundDestroy" value="wooddestroy1" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="Sound_Sight_In" value="crossbow_sight_in" />
+      <property name="Sound_Sight_Out" value="crossbow_sight_out" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <property name="PickupJournalEntry" value="alternateAmmoTip" />
+      <property name="UnlockedBy" value="gunBowT3CompoundCrossbowSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Launcher" />
+        <property name="Hitmask_override" value="Arrow" />
+        <property name="Delay" value=".8" />
+        <property name="Magazine_items" value="ammoCrossbowBoltStone,ammoCrossbowBoltIron,ammoCrossbowBoltSteelAP,ammoCrossbowBoltFlaming,ammoCrossbowBoltExploding" />
+        <property name="Sound_start" value="crossbow2_fire" />
+        <property name="Sound_repeat" value="" />
+        <property name="Sound_end" value="" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="Sound_reload" value="crossbow2_reload" />
+        <property name="AutoReload" value="false" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="55" />
+        <property name="Zoom_max_in" value="55" />
+      </property>
+      <effect_group name="gunBowT3CompoundCrossbow">
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="25" tags="perkArchery" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkArchery" />
+        <passive_effect name="EntityDamage" operation="base_add" value="13.5" tags="perkArchery" />
+        <passive_effect name="MaxRange" operation="base_set" value="100" tags="perkArchery" />
+        <passive_effect name="MagazineSize" operation="base_set" value="1" tags="perkArchery" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value=".5" tags="perkArchery" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkArchery" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkArchery" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkArchery" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkArchery" />
+        <passive_effect name="ProjectileVelocity" operation="perc_add" value="-.08,.08" tags="perkArchery" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkArchery" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkArchery" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="3.35" tags="perkArchery" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="3.35" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".10" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" tags="perkArchery" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2.2" tags="perkArchery" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="2" tags="perkArchery" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".6" tags="perkArchery" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="75" tags="perkArchery" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkArchery" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="2" tags="perkArchery" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="2" tags="perkArchery" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-1" tags="perkArchery" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value="1" tags="perkArchery" />
+        <passive_effect name="DegradationMax" operation="base_set" value="120,250" tier="1,6" tags="perkArchery" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkArchery" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+      </effect_group>
+      <effect_group name="sneak damage bonus">
+        <requirement name="CVarCompare" cvar="_crouching" operation="Equals" value="1" />
+        <requirement name="CVarCompare" cvar="_notAlerted" operation="GT" value="0" target="other" />
+        <passive_effect name="DamageBonus" operation="base_add" value="2" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="2" tags="perkArchery" />
+        <display_value name="dEntityDamageSneak" value="2" />
+      </effect_group>
+      <effect_group name="gunBowT3CompoundCrossbowWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunExplosivesT3RocketLauncherWarden" extends="gunExplosivesT3RocketLauncher" material="Mmetal">
-        <effect_group name="gunExplosivesT3RocketLauncherWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunExplosivesT3RocketLauncherWarden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,holdBreathAiming,reloadPenalty,launcher,attPerception,perkDemolitionsExpert,canHaveCosmetic,barrelAttachments,noSilencer,sideAttachments,smallTopAttachments" />
+      <property name="DisplayType" value="rangedLauncher" />
+      <property name="HoldType" value="10" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/RocketLauncher/rocketlauncherPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="4" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="weapon_jam" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="Sound_Sight_In" value="launcher_sight_in" />
+      <property name="Sound_Sight_Out" value="launcher_sight_out" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="EconomicValue" value="1000" />
+      <property name="UnlockedBy" value="gunExplosivesT3RocketLauncherSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Launcher" />
+        <property name="Delay" value=".8" />
+        <property name="Magazine_items" value="ammoRocketHE,ammoRocketFrag" />
+        <property name="Sound_start" value="m136_fire" />
+        <property name="Sound_repeat" value="" />
+        <property name="Sound_end" value="" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="Sound_reload" value="m136_reload" />
+        <property name="AutoReload" value="false" />
+        <property name="Particles_muzzle_fire" value="rocketLauncherFire" />
+        <property name="Particles_muzzle_smoke" value="nozzlesmoke_m136" />
+        <property name="ScopeOffset" value="-.00062,.088,.065" />
+        <property name="SideOffset" value="0,0,0" />
+        <property name="BarrelOffset" value="0,0,0" />
+        <requirement name="CVarCompare" cvar="_underwater" operation="LT" value=".98" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="55" />
+        <property name="Zoom_max_in" value="55" />
+      </property>
+      <effect_group name="gunExplosivesT3RocketLauncher">
+        <passive_effect name="MaxRange" operation="base_set" value="100" tags="perkDemolitionsExpert" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="70" tags="perkDemolitionsExpert" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkDemolitionsExpert" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkDemolitionsExpert" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkDemolitionsExpert" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkDemolitionsExpert" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkDemolitionsExpert" />
+        <passive_effect name="ProjectileVelocity" operation="perc_add" value="-.08,.08" tags="perkDemolitionsExpert" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkDemolitionsExpert" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkDemolitionsExpert" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="75" tags="perkDemolitionsExpert" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkDemolitionsExpert" />
+        <passive_effect name="MagazineSize" operation="base_set" value="1" tags="perkDemolitionsExpert" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value=".7" tags="perkDemolitionsExpert" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="7" tags="perkDemolitionsExpert" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="7" tags="perkDemolitionsExpert" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".15" tags="perkDemolitionsExpert" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" tags="perkDemolitionsExpert" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" tags="perkDemolitionsExpert" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2" tags="perkDemolitionsExpert" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="10" tags="perkDemolitionsExpert" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="10" tags="perkDemolitionsExpert" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.5" tags="perkDemolitionsExpert" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".5" tags="perkDemolitionsExpert" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="2.2" tags="perkDemolitionsExpert" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".4" tags="perkDemolitionsExpert" />
+        <passive_effect name="DegradationMax" operation="base_set" value="80,150" tier="1,6" tags="perkDemolitionsExpert" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkDemolitionsExpert" />
+      </effect_group>
+      <effect_group name="gunExplosivesT3RocketLauncherWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunHandgunT3DesertVultureWarden" extends="gunHandgunT3DesertVulture" material="Mmetal">
-        <effect_group name="gunHandgunT3DesertVultureWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunHandgunT3DesertVultureWarden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,revolver,holdBreathAiming,reloadPenalty,gun,shortRange,pistol,barrelAttachments,sideAttachments,smallTopAttachments,magazine,firingMode,attAgility,perkGunslinger,attachmentsIncluded,canHaveCosmetic" />
+      <property name="DisplayType" value="rangedGun" />
+      <property name="HoldType" value="75" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/Desert Eagle/DesertEaglePrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="weapon_jam" />
+      <property name="Attachments" value="meleeToolFlashlight02" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="Sound_Sight_In" value="pistol_sight_in" />
+      <property name="Sound_Sight_Out" value="pistol_sight_out" />
+      <property name="LightSource" value="lightSource" />
+      <property name="ActivateObject" value="Attachments/flashlight/lightSource" />
+      <property name="AttachmentFlashlight" value="flashlight02" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="LightValue" value=".45" />
+      <property name="EconomicValue" value="1500" />
+      <property name="UnlockedBy" value="gunHandgunT3DesertVultureSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Ranged" />
+        <property name="Magazine_items" value="ammo44MagnumBulletBall,ammo44MagnumBulletHP,ammo44MagnumBulletAP" />
+        <property name="Sound_start" value="desertvulture_fire" />
+        <property name="Sound_loop" value="desertvulture_fire" />
+        <property name="Sound_end" value="" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="AutoReload" value="false" />
+        <property name="Particles_muzzle_fire" value="gunfire_desertvulture" />
+        <property name="Particles_muzzle_fire_fpv" value="gunfire_desertvulture_fpv" />
+        <requirement name="CVarCompare" cvar="_underwater" operation="LT" value=".98" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="55" />
+        <property name="Zoom_max_in" value="55" />
+        <property name="ScopeCameraOffset" value="0,.0008,0" />
+      </property>
+      <effect_group name="gunHandgunT3DesertVulture">
+        <passive_effect name="MaxRange" operation="base_set" value="50" tags="perkGunslinger" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="25" tags="perkGunslinger" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkGunslinger" />
+        <passive_effect name="EntityDamage" operation="base_add" value="-2" tags="perkGunslinger" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="130" tags="perkGunslinger" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkGunslinger" />
+        <passive_effect name="MagazineSize" operation="base_set" value="8.8" tags="perkGunslinger" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkGunslinger" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkGunslinger" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkGunslinger" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkGunslinger" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkGunslinger" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkGunslinger" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.05,.05" tags="perkGunslinger" />
+        <passive_effect name="MagazineSize" operation="perc_add" value="-.09,.09" tags="perkGunslinger" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkGunslinger" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="1.3" tags="perkGunslinger" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="1.3" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".35" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2.2" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="3.5" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="4" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.3" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".15" tags="perkGunslinger" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="3.2" tags="perkGunslinger" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".6" tags="perkGunslinger" />
+        <passive_effect name="DegradationMax" operation="base_set" value="250,400" tier="1,6" tags="perkGunslinger" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkGunslinger" />
+      </effect_group>
+      <effect_group name="gunHandgunT3DesertVultureWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunHandgunT3SMG5Warden" extends="gunHandgunT3SMG5" material="Mmetal">
-        <effect_group name="gunHandgunT3SMG5Warden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunHandgunT3SMG5Warden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,holdBreathAiming,reloadPenalty,gun,shortRange,barrelAttachments,sideAttachments,smallTopAttachments,magazine,drumMagazine,firingMode,bottomAttachments,attAgility,perkGunslinger,9mmGun,attachmentsIncluded,canHaveCosmetic" />
+      <property name="DisplayType" value="rangedGun" />
+      <property name="HoldType" value="6" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/SMG/SMGPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="weapon_jam" />
+      <property name="Attachments" value="meleeToolFlashlight02" />
+      <property name="TintColor" value="255,255,255" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="Sound_Sight_In" value="smg_sight_in" />
+      <property name="Sound_Sight_Out" value="smg_sight_out" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="LightValue" value=".45" />
+      <property name="EconomicValue" value="1500" />
+      <property name="UnlockedBy" value="gunHandgunT3SMG5Schematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Ranged" />
+        <property name="Delay" value=".150" />
+        <property name="Magazine_items" value="ammo9mmBulletBall,ammo9mmBulletHP,ammo9mmBulletAP" />
+        <property name="Reload_time" value="4.1" />
+        <property name="Sound_start" value="smg_fire" />
+        <property name="Sound_loop" value="smg_fire" />
+        <property name="Sound_end" value="smg_fire_end" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="Sound_reload" value="" />
+        <property name="AutoReload" value="false" />
+        <property name="Particles_muzzle_fire" value="gunfire_SMG" />
+        <property name="Particles_muzzle_fire_fpv" value="gunfire_SMG_fpv" />
+        <property name="ScopeOffset" value="-.000525,.1449,-.2" />
+        <property name="SideOffset" value="0,0,0" />
+        <property name="BarrelOffset" value="-.062,.062,.16" />
+        <requirement name="CVarCompare" cvar="_underwater" operation="LT" value=".98" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="55" />
+        <property name="Zoom_max_in" value="55" />
+        <property name="ScopeCameraOffset" value="-.0003,0,-.01" />
+      </property>
+      <effect_group name="gunHandgunT3SMG5">
+        <passive_effect name="MaxRange" operation="base_set" value="65" tags="perkGunslinger,9mmGun" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="30" tags="perkGunslinger,9mmGun" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkGunslinger,9mmGun" />
+        <passive_effect name="EntityDamage" operation="base_add" value="3" tags="perkGunslinger" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="480" tags="perkGunslinger" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1000" tags="perkGunslinger" />
+        <passive_effect name="MagazineSize" operation="base_set" value="30" tags="perkGunslinger" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkGunslinger" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkGunslinger" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkGunslinger" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkGunslinger" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkGunslinger" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkGunslinger" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.05,.05" tags="perkGunslinger" />
+        <passive_effect name="MagazineSize" operation="perc_add" value="-.122,.122" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkGunslinger" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="1.35" tags="perkGunslinger" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="1.35" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".35" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" tags="perkGunslinger" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2.2" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value=".5" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="1" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.3" tags="perkGunslinger" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".3" tags="perkGunslinger" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="1.6" tags="perkGunslinger,9mmGun" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".8" tags="perkGunslinger" />
+        <passive_effect name="DegradationMax" operation="base_set" value="350,700" tier="1,6" tags="perkGunslinger,9mmGun" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkGunslinger,9mmGun" />
+      </effect_group>
+      <effect_group name="gunHandgunT3SMG5Warden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunMGT3M60Warden" extends="gunMGT3M60" material="Mmetal">
-        <effect_group name="gunMGT3M60Warden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunMGT3M60Warden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,holdBreathAiming,reloadPenalty,gun,barrelAttachments,sideAttachments,smallTopAttachments,magazine,drumMagazine,bottomAttachments,mediumTopAttachments,attFortitude,perkMachineGunner,perkBookAutoWeapons,attachmentsIncluded,canHaveCosmetic" />
+      <property name="DisplayType" value="rangedGun" />
+      <property name="HoldType" value="60" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/MachineGun/m60MachinegunPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="weapon_jam" />
+      <property name="Sound_Sight_In" value="rifle_sight_in" />
+      <property name="Sound_Sight_Out" value="rifle_sight_out" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="EconomicValue" value="1500" />
+      <property name="UnlockedBy" value="perkAutoWeaponsMachineGuns" />
+      <property name="ShowQuality" value="true" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property class="Action0">
+        <property name="Class" value="Ranged" />
+        <property name="Delay" value=".150" />
+        <property name="Magazine_items" value="ammo762mmBulletBall,ammo762mmBulletHP,ammo762mmBulletAP" />
+        <property name="Sound_start" value="m60_fire" />
+        <property name="Sound_loop" value="m60_fire" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="Sound_reload" value="m60_reload" />
+        <property name="Sound_end" value="m60_fire_end" />
+        <property name="AutoReload" value="false" />
+        <property name="Particles_muzzle_fire" value="gunfire_m60" />
+        <property name="Particles_muzzle_smoke" value="gunfire_smoke" />
+        <property name="Particles_muzzle_fire_fpv" value="gunfire_m60_fpv" />
+        <property name="Particles_muzzle_smoke_fpv" value="gunfire_smoke_fpv" />
+        <requirement name="CVarCompare" cvar="_underwater" operation="LT" value=".98" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="55" />
+        <property name="Zoom_max_in" value="55" />
+        <property name="ScopeCameraOffset" value="-.00062,0,.055" />
+      </property>
+      <effect_group name="gunMGT3M60">
+        <passive_effect name="MaxRange" operation="base_set" value="90" tags="perkMachineGunner" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="50" tags="perkMachineGunner" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkMachineGunner" />
+        <passive_effect name="EntityDamage" operation="base_add" value="-3" tags="perkMachineGunner" />
+        <passive_effect name="BlockDamage" operation="base_add" value="-2" tags="perkMachineGunner" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkMachineGunner" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMachineGunner" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkMachineGunner" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMachineGunner" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkMachineGunner" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.05,.05" tags="perkMachineGunner" />
+        <passive_effect name="MagazineSize" operation="perc_add" value="-.122,.122" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkMachineGunner" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="440" tags="perkMachineGunner" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1000" tags="perkMachineGunner" />
+        <passive_effect name="MagazineSize" operation="base_set" value="60" tags="perkMachineGunner" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkMachineGunner" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="2.8" tags="perkMachineGunner" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="2.8" tags="perkMachineGunner" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".33" tags="perkMachineGunner" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" tags="perkMachineGunner" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" tags="perkMachineGunner" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2.2" tags="perkMachineGunner" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="-.4" tags="perkMachineGunner" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="1.1" tags="perkMachineGunner" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-1" tags="perkMachineGunner" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value="1" tags="perkMachineGunner" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="1.5" tags="perkMachineGunner" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".83" tags="perkMachineGunner" />
+        <passive_effect name="DegradationMax" operation="base_set" value="300,650" tier="1,6" tags="perkMachineGunner,perkBookAutoWeapons" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkMachineGunner,perkBookAutoWeapons" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+      </effect_group>
+      <effect_group name="gunMGT3M60Warden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunRifleT3SniperRifleWarden" extends="gunRifleT3SniperRifle" material="Mmetal">
-        <effect_group name="gunRifleT3SniperRifleWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunRifleT3SniperRifleWarden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,holdBreathAiming,reloadPenalty,gun,barrelAttachments,sideAttachments,smallTopAttachments,mediumTopAttachments,largeTopAttachments,stock,magazine,firingMode,bottomAttachments,attPerception,perkDeadEye,attachmentsIncluded,canHaveCosmetic" />
+      <property name="DisplayType" value="rangedGun" />
+      <property name="HoldType" value="77" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/Sharp Shooter/sharpShooterGunPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="weapon_jam" />
+      <property name="Attachments" value="meleeToolFlashlight02" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="Sound_Sight_In" value="rifle_sight_in" />
+      <property name="Sound_Sight_Out" value="rifle_sight_out" />
+      <property name="LightSource" value="lightSource" />
+      <property name="ActivateObject" value="Attachments/flashlight/lightSource" />
+      <property name="AttachmentFlashlight" value="meleeToolFlashlight02" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="LightValue" value=".45" />
+      <property name="EconomicValue" value="1500" />
+      <property name="UnlockedBy" value="gunRifleT3SniperRifleSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Ranged" />
+        <property name="Delay" value=".5" />
+        <property name="Magazine_items" value="ammo762mmBulletBall,ammo762mmBulletHP,ammo762mmBulletAP" />
+        <property name="Reload_time" value="2.5" />
+        <property name="Sound_start" value="sharpshooter_fire" />
+        <property name="Sound_loop" value="sharpshooter_fire" />
+        <property name="Sound_repeat" value="" />
+        <property name="Sound_end" value="" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="AutoReload" value="false" />
+        <property name="Particles_muzzle_fire" value="gunfire_sniper" />
+        <property name="Particles_muzzle_fire_fpv" value="gunfire_sniper_fpv" />
+        <requirement name="CVarCompare" cvar="_underwater" operation="LT" value=".98" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="55" />
+        <property name="Zoom_max_in" value="55" />
+        <property name="ScopeCameraOffset" value="0,.0262,-.05" />
+      </property>
+      <effect_group name="gunRifleT3SniperRifle">
+        <passive_effect name="MaxRange" operation="base_set" value="150" tags="perkDeadEye" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="70" tags="perkDeadEye" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkDeadEye" />
+        <passive_effect name="EntityDamage" operation="base_add" value="17" tags="perkDeadEye" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="140" tags="perkDeadEye" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkDeadEye" />
+        <passive_effect name="MagazineSize" operation="base_set" value="12" tags="perkDeadEye" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkDeadEye" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkDeadEye" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkDeadEye" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkDeadEye" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkDeadEye" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkDeadEye" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.05,.05" tags="perkDeadEye" />
+        <passive_effect name="MagazineSize" operation="base_add" value="-.5,1.6" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkDeadEye" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="6" tags="perkDeadEye" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="6" tags="perkDeadEye" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".06" tags="perkDeadEye" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" tags="perkDeadEye" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" tags="perkDeadEye" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2" tags="perkDeadEye" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="1.5" tags="perkDeadEye" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="3.0" tags="perkDeadEye" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.2" tags="perkDeadEye" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".2" tags="perkDeadEye" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="11" tags="perkDeadEye" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".75" tags="perkDeadEye" />
+        <passive_effect name="DegradationMax" operation="base_set" value="250,500" tier="1,6" tags="perkDeadEye" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkDeadEye" />
+      </effect_group>
+      <effect_group name="gunRifleT3SniperRifleWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="gunShotgunT3AutoShotgunWarden" extends="gunShotgunT3AutoShotgun" material="Mmetal">
-        <effect_group name="gunShotgunT3AutoShotgunWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="gunShotgunT3AutoShotgunWarden" material="Mmetal">
+      <property name="Tags" value="weapon,ranged,holdBreathAiming,reloadPenalty,gun,shotgun,shortRange,barrelAttachments,sideAttachments,smallTopAttachments,noScopes,stock,magazine,drumMagazine,firingMode,bottomAttachments,attStrength,perkBoomstick,attachmentsIncluded,canHaveCosmetic" />
+      <property name="DisplayType" value="rangedShotgun" />
+      <property name="HoldType" value="76" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Ranged/Auto Shotgun/autoShotgunPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="weapon_jam" />
+      <property name="Attachments" value="meleeToolFlashlight02" />
+      <property name="CrosshairOnAim" value="true" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="Sound_Sight_In" value="rifle_sight_in" />
+      <property name="Sound_Sight_Out" value="rifle_sight_out" />
+      <property name="LightSource" value="lightSource" />
+      <property name="ActivateObject" value="Attachments/flashlight/lightSource" />
+      <property name="AttachmentFlashlight" value="meleeToolFlashlight02" />
+      <property name="Group" value="Ammo/Weapons,Ranged Weapons" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="PickupJournalEntry" value="alternateAmmoTip" />
+      <property name="LightValue" value=".45" />
+      <property name="EconomicValue" value="1500" />
+      <property name="UnlockedBy" value="gunShotgunT3AutoShotgunSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Ranged" />
+        <property name="Delay" value=".8" />
+        <property name="Magazine_items" value="ammoShotgunShell,ammoShotgunSlug,ammoShotgunBreachingSlug" />
+        <property name="Reload_time" value="2.6" />
+        <property name="Sound_start" value="autoshotgun_fire" />
+        <property name="Sound_loop" value="autoshotgun_fire" />
+        <property name="Sound_repeat" value="" />
+        <property name="Sound_end" value="" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="AutoReload" value="false" />
+        <property name="Particles_muzzle_fire" value="gunfire_autoshotgun" />
+        <property name="Particles_muzzle_fire_fpv" value="gunfire_autoshotgun_fpv" />
+        <property name="ScopeOffset" value="-.00062,.088,.065" />
+        <property name="SideOffset" value="0,0,0" />
+        <property name="BarrelOffset" value="0,0,0" />
+        <requirement name="CVarCompare" cvar="_underwater" operation="LT" value=".98" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Zoom" />
+        <property name="Zoom_max_out" value="55" />
+        <property name="Zoom_max_in" value="55" />
+        <property name="ScopeCameraOffset" value="0,0,0" />
+      </property>
+      <effect_group name="gunShotgunT3AutoShotgun">
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="70" tags="perkBoomstick" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkBoomstick" />
+        <passive_effect name="MagazineSize" operation="base_set" value="16" tags="perkBoomstick" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkBoomstick" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkBoomstick" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkBoomstick" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkBoomstick" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkBoomstick" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkBoomstick" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.05,.05" tags="perkBoomstick" />
+        <passive_effect name="MagazineSize" operation="perc_add" value="-.122,.24" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.085,.085" tags="perkBoomstick" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="4.2" tags="perkBoomstick" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value="4.2" tags="perkBoomstick" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-2.5" tags="perkBoomstick" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value="2.5" tags="perkBoomstick" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="2" tags="perkBoomstick" />
+        <passive_effect name="WeaponHandling" operation="base_set" value="1.7" tags="perkBoomstick" />
+        <passive_effect name="DegradationMax" operation="base_set" value="160,500" tier="1,6" tags="perkBoomstick" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkBoomstick" />
+        <display_value name="dStatStunEffect" value="4" />
+      </effect_group>
+      <effect_group name="gunShotgunT3AutoShotgunWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeToolAxeT3ChainsawWarden" extends="meleeToolAxeT3Chainsaw" material="Mmetal">
-        <effect_group name="meleeToolAxeT3ChainsawWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeToolAxeT3ChainsawWarden" material="Mmetal">
+      <property name="Tags" value="melee,heavy,tool,motorTool,attStrength,perkMiner69r,perkMotherLode,chainsaw,canHaveCosmetic" />
+      <property name="DisplayType" value="motorTool" />
+      <property name="HoldType" value="19" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Melee/Chainsaw/chainsawPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="SoundIdle" value="chainsaw_idle" />
+      <property name="Group" value="Tools/Traps" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="EconomicValue" value="1500" />
+      <property name="UnlockedBy" value="meleeToolAxeT3ChainsawSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Ranged" />
+        <property name="Hitmask_override" value="Melee" />
+        <property name="UseMeleeCrosshair" value="true" />
+        <property name="Single_magazine_usage" value="false" />
+        <property name="Magazine_items" value="ammoGasCan" />
+        <property name="Bullet_material" value="metal" />
+        <property name="Reload_time" value="4.1" />
+        <property name="Sound_start" value="chainsaw_fire_start" />
+        <property name="Sound_empty" value="chainsaw_empty" />
+        <property name="Sound_repeat" value="Sounds/Weapons/Motorized/Chainsaw/chainsaw_fire_lp" />
+        <property name="Sound_end" value="Sounds/Weapons/Motorized/Chainsaw/chainsaw_fire_end" />
+        <property name="Sound_reload" value="chainsaw_reload" />
+        <property name="AutoReload" value="true" />
+        <property name="Particles_muzzle_smoke" value="nozzlesmoke_chainsaw" />
+        <property name="SupportHarvesting" value="true" />
+        <property name="ToolCategory.harvestingTools" value="1" param1="1" />
+      </property>
+      <effect_group name="meleeToolAxeT3Chainsaw">
+        <passive_effect name="EntityDamage" operation="base_set" value="6" tags="perkMiner69r" />
+        <passive_effect name="BlockDamage" operation="base_set" value="24.3" tags="perkMiner69r" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="300" tags="perkMiner69r" />
+        <passive_effect name="DegradationMax" operation="base_set" value="1400,4200" tier="1,6" tags="perkMiner69r" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.35" tags="perkMiner69r" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkMiner69r" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="SphereCastRadius" operation="base_set" value=".1" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="100" tags="perkMiner69r" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkMiner69r" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkMiner69r" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMiner69r" />
+        <passive_effect name="PlayerExpGain" operation="perc_add" value="-.3" tags="Harvesting" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkMiner69r" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMiner69r" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkMiner69r" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.05,.05" tags="perkMiner69r" />
+        <passive_effect name="MagazineSize" operation="perc_add" value="-.122,.122" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkMiner69r" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.85" tags="earth" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.85" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.85" tags="metal" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1000" tags="perkMiner69r" />
+        <passive_effect name="MagazineSize" operation="base_set" value="300" tags="perkMiner69r" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value=".5" tags="perkMiner69r" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value=".5" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="-.25" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value=".25" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.45" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".45" tags="perkMiner69r" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="WeaponHandling" operation="base_set" value="5" tags="perkMiner69r" />
+      </effect_group>
+      <effect_group name="meleeToolAxeT3ChainsawWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+        <passive_effect name="HarvestCount" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeToolFarmT1IronHoeWarden" extends="meleeToolFarmT1IronHoe" material="Mmetal">
-        <effect_group name="meleeToolFarmT1IronHoeWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeToolFarmT1IronHoeWarden" material="Mmetal">
+      <property name="CreativeMode" value="None" />
+      <property name="Tags" value="melee,medium,tool,attFortitude,perkLivingOffTheLand,canHaveCosmetic" />
+      <property name="DisplayType" value="melee" />
+      <property name="HoldType" value="50" />
+      <property name="Meshfile" value="#Other/Items?Tools/hoe_ironPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="ItemNeedsRepair" />
+      <property name="SoundDestroy" value="wooddestroy1" />
+      <property name="EconomicValue" value="350" />
+      <property name="UnlockedBy" value="perkLivingOffTheLand,meleeToolFarmT1IronHoeSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Sphere" value=".15" />
+        <property name="Sound_start" value="swoosh" />
+        <property name="ToolCategory.cropHarvest" value="1" param1="1" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".5" />
+        <property name="GrazeEnd" value=".55" />
+        <property name="SwingDegrees" value="65" />
+        <property name="SwingAngle" value="160" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Repair" />
+        <property name="Repair_amount" value="50" />
+        <property name="Upgrade_hit_offset" value="-4" />
+        <property name="Sound_start" value="repair_block" />
+        <property name="Delay" value="1.3" />
+        <property name="Upgrade_action_sound" value="ImpactSurface/metalhitearth" />
+        <property name="Allowed_upgrade_items" value="resourceClayLump" />
+      </property>
+      <effect_group name="meleeToolFarmT1IronHoe">
+        <passive_effect name="EntityDamage" operation="base_set" value="13.2" tags="perkLivingOffTheLand" />
+        <passive_effect name="BlockDamage" operation="base_set" value="26" tags="perkLivingOffTheLand" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="49" tags="perkLivingOffTheLand" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="16.1" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="196,668" tier="1,6" tags="perkLivingOffTheLand" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkLivingOffTheLand" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.6" tags="perkLivingOffTheLand" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkLivingOffTheLand" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkLivingOffTheLand" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkLivingOffTheLand" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkLivingOffTheLand" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkLivingOffTheLand" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="wood" />
+        <passive_effect name="DamageModifier" operation="perc_set" value="-.9" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_set" value="-.9" tags="metal" />
+      </effect_group>
+      <property name="Group" value="Tools/Traps" />
+      <property name="PickupJournalEntry" value="farmingTip" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <effect_group name="meleeToolFarmT1IronHoeWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+        <passive_effect name="HarvestCount" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeToolPickT3AugerWarden" extends="meleeToolPickT3Auger" material="Mmetal">
-        <effect_group name="meleeToolPickT3AugerWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeToolPickT3AugerWarden" material="Mmetal">
+      <property name="Tags" value="melee,heavy,tool,motorTool,attStrength,perkMiner69r,perkMotherLode,miningTool,canHaveCosmetic" />
+      <property name="DisplayType" value="motorTool" />
+      <property name="HoldType" value="20" />
+      <property name="Meshfile" value="#Other/Items?Tools/auger/augerPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="SoundIdle" value="auger_idle" />
+      <property name="Particles_muzzle_smoke" value="nozzlesmoke_chainsaw" />
+      <property name="Group" value="Tools/Traps" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="EconomicValue" value="1500" />
+      <property name="UnlockedBy" value="meleeToolPickT3AugerSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Ranged" />
+        <property name="Hitmask_override" value="Melee" />
+        <property name="UseMeleeCrosshair" value="true" />
+        <property name="Single_magazine_usage" value="false" />
+        <property name="Magazine_items" value="ammoGasCan" />
+        <property name="Bullet_material" value="metal" />
+        <property name="Reload_time" value="4.1" />
+        <property name="Sound_start" value="Auger_Fire_Start" />
+        <property name="Sound_repeat" value="Weapons/Motorized/Auger/auger_fire_lp" />
+        <property name="Sound_end" value="Weapons/Motorized/Auger/auger_fire_end" />
+        <property name="Sound_empty" value="auger_empty" />
+        <property name="Sound_reload" value="Auger_Reload" />
+        <property name="AutoReload" value="true" />
+        <property name="Particles_muzzle_smoke" value="nozzlesmoke_chainsaw" />
+        <property name="SupportHarvesting" value="true" />
+        <property name="ToolCategory.harvestingTools" value="1" param1="1" />
+      </property>
+      <effect_group name="meleeToolPickT3Auger">
+        <passive_effect name="EntityDamage" operation="base_set" value="4.2" tags="perkMiner69r" />
+        <passive_effect name="BlockDamage" operation="base_set" value="20.7" tags="perkMiner69r,miningTool" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="300" tags="perkMiner69r" />
+        <passive_effect name="DegradationMax" operation="base_set" value="1400,4200" tier="1,6" tags="perkMiner69r" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.35" tags="perkMiner69r" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkMiner69r" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="SphereCastRadius" operation="base_set" value=".1" />
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="100" tags="perkMiner69r" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkMiner69r" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkMiner69r" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMiner69r" />
+        <passive_effect name="PlayerExpGain" operation="perc_add" value="-.3" tags="Harvesting" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkMiner69r" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMiner69r" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.2,.2" tags="perkMiner69r" />
+        <passive_effect name="RoundsPerMinute" operation="perc_add" value="-.05,.05" tags="perkMiner69r" />
+        <passive_effect name="MagazineSize" operation="perc_add" value="-.122,.122" />
+        <passive_effect name="WeaponHandling" operation="perc_add" value="-.08,.08" tags="perkMiner69r" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.8" tags="wood" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1000" tags="perkMiner69r" />
+        <passive_effect name="MagazineSize" operation="base_set" value="300" tags="perkMiner69r" />
+        <passive_effect name="ReloadSpeedMultiplier" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value=".5" tags="perkMiner69r" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value=".5" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="-.35" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value=".35" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.35" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".35" tags="perkMiner69r" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="WeaponHandling" operation="base_set" value="5" tags="perkMiner69r" />
+      </effect_group>
+      <effect_group name="meleeToolPickT3AugerWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+        <passive_effect name="HarvestCount" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeToolRepairT3NailgunWarden" extends="meleeToolRepairT3Nailgun" material="Mmetal">
-        <property name="DisplayName" value="Warden Nailgun"/>
-        <property name="CreativeMode" value="None"/>
-        <property name="CustomIconTint" value="FFD700"/>
-        <property name="EconomicValue" value="5000"/>
-        <property name="ShowQuality" value="true"/>
-
-        <property class="Action0"> <!-- Fire -->
-            <property name="Class" value="Launcher"/>
-            <property name="Magazine_items" value="resourceNail"/>
-            <property name="Reload_time" value="1"/>
-            <property name="Sound_start" value="nailgun_fire"/>
-            <property name="Particles_muzzle_fire" value="nailgunfire"/>
-            <property name="AutoReload" value="true"/>
+    <item name="meleeToolRepairT3NailgunWarden" material="Mmetal">
+      <property name="Tags" value="tool,nailgun,sideAttachments,repairTool,attStrength,perkMiner69r,canHaveCosmetic,noMods" />
+      <property name="DisplayType" value="rangedRepairTool" />
+      <property name="HoldType" value="37" />
+      <property name="Meshfile" value="#Other/Items?Tools/nailgunPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="10" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="weapon_jam" />
+      <property name="CrosshairUpAfterShot" value="true" />
+      <property name="Stacknumber" value="1" />
+      <property name="UnlockedBy" value="perkAdvancedEngineering,meleeToolRepairT3NailgunSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Launcher" />
+        <property name="Hitmask_override" value="Arrow" />
+        <property name="Delay" value=".3" />
+        <property name="Magazine_items" value="resourceNail" />
+        <property name="Instantiate_on_load" value="false" />
+        <property name="Reload_time" value="2" />
+        <property name="Sound_start" value="nailgun_fire" />
+        <property name="Particles_muzzle_fire" value="nailgunfire" />
+        <property name="Sound_repeat" value="" />
+        <property name="Sound_end" value="" />
+        <property name="Sound_empty" value="dryfire" />
+        <property name="Sound_reload" value="nailgun_reload" />
+        <property name="AutoReload" value="false" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Repair" />
+        <property name="Delay" value=".5" />
+        <property name="Repair_amount" value="1000" />
+        <property name="Upgrade_hit_offset" value="-5" />
+        <property name="Repair_action_sound" value="nailgun_fire" />
+        <property name="Upgrade_action_sound" value="nailgun_fire" />
+        <property name="Allowed_upgrade_items" value="resourceWood,resourceClayLump,resourceSnowBall,resourceScrapIron,resourceForgedIron,resourceForgedSteel,resourceConcreteMix,resourceCobblestones,ironDoor1_v1,vaultDoor01,scrapHatch_v1,vaultHatch_v1,cellarDoorDoubleIron,cellarDoorDoubleSteel,shuttersIronBlockVariantHelper,shuttersSteelBlockVariantHelper,resourceYuccaFibers,resourceCloth,resourceScrapPolymers,resourceNail" />
+      </property>
+      <property name="Group" value="Tools/Traps" />
+      <property name="RepairExpMultiplier" value="10.8" />
+      <property name="EconomicValue" value="1000" />
+      <effect_group name="meleeToolRepairT3Nailgun" tiered="false">
+        <passive_effect name="DamageFalloffRange" operation="base_set" value="3" tags="perkMiner69r" />
+        <passive_effect name="DamageFalloffRange" operation="perc_add" value="-.2,.2" tags="perkMiner69r" />
+        <passive_effect name="MaxRange" operation="base_set" value="10" tags="perkMiner69r" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value="1.3" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value="1.3" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value=".4" />
+        <passive_effect name="SpreadMultiplierCrouching" operation="base_set" value=".8" />
+        <passive_effect name="SpreadMultiplierWalking" operation="base_set" value="1.5" />
+        <passive_effect name="SpreadMultiplierRunning" operation="base_set" value="2.2" />
+        <display_value name="dBlockRepairAmount" value="1000" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="2" tags="perkMiner69r" />
+        <passive_effect name="WeaponHandling" operation="base_set" value=".7" tags="perkMiner69r" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="257" tags="perkMiner69r" />
+        <passive_effect name="BurstRoundCount" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="MagazineSize" operation="base_set" value="10" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="-.7" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value=".7" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.6" tags="perkMiner69r" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".6" tags="perkMiner69r" />
+        <passive_effect name="DegradationMax" operation="base_set" value="1000" tags="nailgun" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="nailgun" />
+        <passive_effect name="ModSlots" operation="base_set" value="0" />
+      </effect_group>
+      <effect_group name="meleeToolRepairT3NailgunWarden">
+        <passive_effect name="EntityDamage" operation="base_set" value="32" tags="perkMiner69r" />
+        <passive_effect name="BlockDamage" operation="base_set" value="16" tags="perkMiner69r" />
+        <passive_effect name="RoundsPerMinute" operation="base_set" value="500" tags="perkMiner69r" />
+        <passive_effect name="MagazineSize" operation="base_set" value="60" />
+        <passive_effect name="DegradationMax" operation="base_set" value="6000" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" />
+        <passive_effect name="MaxRange" operation="base_set" value="10" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" />
+        <passive_effect name="ModSlots" operation="base_set" value="6" />
+        <passive_effect name="WeaponHandling" operation="base_set" value="1.0" />
+        <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="-.25" />
+        <passive_effect name="KickDegreesVerticalMax" operation="base_set" value=".25" />
+        <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.2" />
+        <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".2" />
+        <passive_effect name="SpreadDegreesVertical" operation="base_set" value=".3" />
+        <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value=".3" />
+        <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="0.5" />
+        <passive_effect name="ZoomFOV" operation="base_set" value="45" />
+        <passive_effect name="AimDuration" operation="base_set" value="0.1" />
+        <passive_effect name="SpreadMultiplierAiming" operation="base_set" value="0.3" />
+      </effect_group>
+      <property name="DisplayName" value="Warden Nailgun" />
+      <property name="CreativeMode" value="None" />
+      <property name="CustomIconTint" value="FFD700" />
+      <property name="EconomicValue" value="5000" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="Launcher" />
+        <property name="Magazine_items" value="resourceNail" />
+        <property name="Reload_time" value="1" />
+        <property name="Sound_start" value="nailgun_fire" />
+        <property name="Particles_muzzle_fire" value="nailgunfire" />
+        <property name="AutoReload" value="true" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="Repair" />
+        <property name="Delay" value="0.1" />
+        <property name="Repair_amount" value="5000" />
+        <property name="Upgrade_hit_offset" value="-5" />
+        <property name="Sound_start" value="nailgun_fire" />
+        <property name="Allowed_upgrade_items" value="resourceWood,resourceConcreteMix,resourceForgedSteel,resourceCobblestones" />
+        <property name="UsePowerAttackAnimation" value="false" />
+      </property>
+    </item>
+    <item name="meleeToolSalvageT3ImpactDriverWarden" material="Mmetal">
+      <property name="Tags" value="blunt,melee,grunting,light,tool,attPerception,perkSalvageOperations,canHaveCosmetic" />
+      <property name="DisplayType" value="melee" />
+      <property name="HoldType" value="74" />
+      <property name="Meshfile" value="#Other/Items?Tools/impactDriverPrefab.prefab" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="ItemNeedsRepair" />
+      <property name="SoundDestroy" value="metaldestroy" />
+      <property name="EconomicValue" value="1500" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="UnlockedBy" value="meleeToolSalvageT3ImpactDriverSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property name="Stacknumber" value="1" />
+      <property class="Action0">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Sound_start" value="swoosh" />
+        <property name="ToolCategory.harvestingTools" value=".5" param1="1" />
+        <property name="ToolCategory.Disassemble" value="1" param1="1" />
+        <property name="Particle_harvesting" value="true" param1="metal" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".25" />
+        <property name="GrazeEnd" value=".3" />
+        <property name="SwingDegrees" value="50" />
+        <property name="SwingAngle" value="180" />
+      </property>
+      <property class="Action1">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Sound_start" value="swoosh" />
+        <property name="ToolCategory.harvestingTools" value=".5" param1="1" />
+      </property>
+      <effect_group name="meleeToolSalvageT3ImpactDriver">
+        <passive_effect name="EntityDamage" operation="base_set" value="16.5" tags="perkSalvageOperations" />
+        <passive_effect name="BlockDamage" operation="base_set" value="58" tags="perkSalvageOperations" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="50" tags="perkSalvageOperations" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="24.7" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="500,1100" tier="1,6" tags="perkSalvageOperations" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkSalvageOperations" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.4" tags="perkSalvageOperations" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkSalvageOperations" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkSalvageOperations" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkSalvageOperations" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkSalvageOperations" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkSalvageOperations" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="wood" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.75" tags="earth" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="stone" />
+        <passive_effect name="HarvestCount" operation="base_set" value="1" tags="salvageHarvest" />
+      </effect_group>
+      <effect_group name="Power Attack">
+        <passive_effect name="EntityDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="41.9" tags="secondary" />
+      </effect_group>
+      <property name="Group" value="Tools/Traps" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <effect_group name="meleeToolSalvageT3ImpactDriverWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+        <passive_effect name="HarvestCount" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
+    </item>
+    <item name="meleeToolShovelT2SteelShovelWarden" material="Mmetal">
+      <property name="Extends" value="meleeToolShovelT1IronShovel" />
+      <property name="Tags" value="melee,grunting,medium,tool,longShaft,shovel,attStrength,perkMiner69r,perkMotherLode,canHaveCosmetic" />
+      <property name="Meshfile" value="#Other/Items?Tools/shovel_steelPrefab.prefab" />
+      <property name="CustomIcon" value="meleeToolShovelT1IronShovel" />
+      <property name="CustomIconTint" value="a0a0ff" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="EconomicValue" value="1000" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="UnlockedBy" value="meleeToolSteelSetSchematic" />
+      <effect_group name="meleeToolShovelT2SteelShovel">
+        <passive_effect name="EntityDamage" operation="base_set" value="17.4" tags="perkMiner69r" />
+        <passive_effect name="BlockDamage" operation="base_set" value="69" tags="perkMiner69r" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="50" tags="perkMiner69r" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="24.7" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="300,1100" tier="1,6" tags="perkMiner69r" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkMiner69r" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.6" tags="perkMiner69r" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkMiner69r" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkMiner69r" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMiner69r" />
+        <passive_effect name="PlayerExpGain" operation="perc_add" value="-.1" tags="Harvesting" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkMiner69r" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkMiner69r" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="-.15,.15" tags="perkMiner69r" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="-.05,.05" tags="perkMiner69r" />
+        <passive_effect name="StaminaLoss" operation="perc_add" value="-.05,.05" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.7" tags="wood" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.8" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.8" tags="metal" />
+      </effect_group>
+      <effect_group name="Power Attack">
+        <passive_effect name="EntityDamage" operation="perc_add" value="1.25" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="1.25" tags="secondary" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="-.3" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="49.3" tags="secondary" />
+      </effect_group>
+      <effect_group name="meleeToolShovelT2SteelShovelWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+        <passive_effect name="HarvestCount" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
+    </item>
+    <item name="meleeWpnBatonT2StunBatonWarden" material="Mmetal">
+      <property name="Tags" value="melee,grunting,light,perkFlurryOfBlows,weapon,meleeWeapon,attIntellect,perkElectrocutioner,canHaveCosmetic" />
+      <property name="DisplayType" value="melee" />
+      <property name="HoldType" value="58" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Melee/TaserBaton/TaserBatonPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="4" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="EconomicValue" value="350" />
+      <property name="SoundJammed" value="ItemNeedsRepair" />
+      <property name="SoundDestroy" value="wooddestroy1" />
+      <property name="Group" value="Ammo/Weapons,Melee Weapons" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <property name="UnlockedBy" value="perkElectrocutioner,meleeWpnBatonT2StunBatonSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Damage_type" value="Slashing" />
+        <property name="Sphere" value=".15" />
+        <property name="Sound_start" value="stunbaton_swinglight" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".25" />
+        <property name="GrazeEnd" value=".32" />
+        <property name="SwingDegrees" value="90" />
+        <property name="SwingAngle" value="90" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalhollowhitorganic" />
         </property>
-
-        <property class="Action1"> <!-- Reinforce -->
-            <property name="Class" value="Repair"/>
-            <property name="Delay" value="0.1"/>
-            <property name="Repair_amount" value="5000"/>
-            <property name="Upgrade_hit_offset" value="-5"/>
-            <property name="Sound_start" value="nailgun_fire"/>
-            <property name="Allowed_upgrade_items" value="resourceWood,resourceConcreteMix,resourceForgedSteel,resourceCobblestones"/>
-            <property name="UsePowerAttackAnimation" value="false"/>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
         </property>
-
-        <effect_group name="meleeToolRepairT3NailgunWarden">
-            <passive_effect name="EntityDamage" operation="base_set" value="32" tags="perkMiner69r"/>
-            <passive_effect name="BlockDamage" operation="base_set" value="16" tags="perkMiner69r"/>
-            <passive_effect name="RoundsPerMinute" operation="base_set" value="500" tags="perkMiner69r"/>
-            <passive_effect name="MagazineSize" operation="base_set" value="60"/>
-            <passive_effect name="DegradationMax" operation="base_set" value="6000"/>
-            <passive_effect name="DegradationPerUse" operation="base_set" value="1"/>
-            <passive_effect name="MaxRange" operation="base_set" value="10"/>
-            <passive_effect name="BlockRange" operation="base_set" value="3.5"/>
-            <passive_effect name="ModSlots" operation="base_set" value="6"/>
-            <passive_effect name="WeaponHandling" operation="base_set" value="1.0"/>
-            <passive_effect name="KickDegreesVerticalMin" operation="base_set" value="-.25"/>
-            <passive_effect name="KickDegreesVerticalMax" operation="base_set" value=".25"/>
-            <passive_effect name="KickDegreesHorizontalMin" operation="base_set" value="-.2"/>
-            <passive_effect name="KickDegreesHorizontalMax" operation="base_set" value=".2"/>
-            <passive_effect name="SpreadDegreesVertical" operation="base_set" value=".3"/>
-            <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value=".3"/>
-            <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="0.5"/>
-
-            <!-- ZOOM + Precision -->
-            <passive_effect name="ZoomFOV" operation="base_set" value="45"/>
-            <passive_effect name="AimDuration" operation="base_set" value="0.1"/>
-            <passive_effect name="SpreadMultiplierAiming" operation="base_set" value="0.3"/>
-        </effect_group>
+      </property>
+      <property class="Action1">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Damage_type" value="Slashing" />
+        <property name="Sphere" value=".15" />
+        <property name="Sound_start" value="stunbaton_swingheavy" />
+        <property name="UsePowerAttackAnimation" value="true" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".2" />
+        <property name="GrazeEnd" value=".32" />
+        <property name="SwingDegrees" value="65" />
+        <property name="SwingAngle" value="180" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalhollowhitorganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <effect_group name="meleeWpnBatonT2StunBaton">
+        <passive_effect name="EntityDamage" operation="base_set" value="10.8" tags="perkElectrocutioner" />
+        <passive_effect name="BlockDamage" operation="base_set" value="6" tags="perkElectrocutioner" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="70" tags="perkElectrocutioner,perkFlurryOfBlows" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="15.5" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="269,673" tier="1,6" tags="perkElectrocutioner" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkElectrocutioner" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.4" tags="perkElectrocutioner" />
+        <passive_effect name="BlockRange" operation="base_set" value="3" tags="perkElectrocutioner" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkElectrocutioner" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkElectrocutioner" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkElectrocutioner" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkElectrocutioner" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.9" tags="earth" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.9" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.9" tags="metal" />
+        <passive_effect name="HarvestCount" operation="base_set" value="1" tags="butcherHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allToolsHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="oreWoodHarvest" />
+        <triggered_effect trigger="onSelfEquipStart" action="AddPart" part="Sparks" prefab="ParticleEffects/p_electric_shock_small" parentTransform="Handle" localPos="0,0,0" localRot="0,0,0">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="4" />
+        </triggered_effect>
+      </effect_group>
+      <effect_group name="Power Attack">
+        <passive_effect name="EntityDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="26.4" tags="secondary" />
+      </effect_group>
+      <effect_group name="apply damage buff, meleeWpnBatonT2StunBaton">
+        <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="40" />
+        <triggered_effect trigger="onSelfEquipStart" action="AddPart" part="Sparks" prefab="ItemModEffects/baton_electricityPrefab" parentTransform="Handle" localPos="0,0,0" localRot="0,0,0" />
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="Ragdoll" target="other" duration="2.5" force="350">
+          <requirement name="HasBuff" buff="buffmodMeleeStunBatonRepulsor" />
+          <requirement name="!HasBuff" buff="buffDrugNerdTats" />
+          <requirement name="!EntityTagCompare" target="other" tags="trader" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="Ragdoll" target="other" duration="2.5" force="350">
+          <requirement name="HasBuff" buff="buffmodMeleeStunBatonRepulsor" />
+          <requirement name="!HasBuff" buff="buffDrugNerdTats" />
+          <requirement name="!EntityTagCompare" target="other" tags="trader" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="Ragdoll" target="otherAOE" range="1.1" target_tags="zombie,animal" duration="2.5" force="350">
+          <requirement name="HasBuff" buff="buffmodMeleeStunBatonRepulsor" />
+          <requirement name="HasBuff" buff="buffDrugNerdTats" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="Ragdoll" target="otherAOE" range="1.1" target_tags="zombie,animal" duration="2.5" force="350">
+          <requirement name="HasBuff" buff="buffmodMeleeStunBatonRepulsor" />
+          <requirement name="HasBuff" buff="buffDrugNerdTats" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="5">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="1" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="6">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="2" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="7">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="3" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="8">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="4" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="9">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="5" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="5">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="1" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="6">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="2" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="7">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="3" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="8">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="4" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" target="other" cvar=".buffShockedDurationStart" operation="set" value="9">
+          <requirement name="ProgressionLevel" progression_name="perkElectrocutioner" operation="Equals" value="5" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="AddBuff" target="other" buff="buffShocked" />
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="AddBuff" target="other" buff="buffShocked" />
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="AddBuff" target="otherAOE" range="1.1" target_tags="zombie,animal" buff="buffShocked">
+          <requirement name="HasBuff" buff="buffDrugNerdTats" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="AddBuff" target="otherAOE" range="1.3" target_tags="zombie,animal" buff="buffShocked">
+          <requirement name="HasBuff" buff="buffDrugNerdTats" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="RemovePart" part="Sparks" />
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="RemovePart" part="Sparks" />
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" cvar=".stunBatonCharge" operation="set" value="0" />
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" cvar=".stunBatonCharge" operation="set" value="0" />
+      </effect_group>
+      <effect_group name="increase charges">
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" cvar=".stunBatonCharge" operation="add" value="1">
+          <requirement name="IsAlive" target="other" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" cvar=".stunBatonCharge" operation="add" value="2">
+          <requirement name="IsAlive" target="other" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="ModifyCVar" cvar=".stunBatonCharge" operation="add" value="4">
+          <requirement name="ProgressionLevel" progression_name="perkTechJunkie6BatonCharge" operation="Equals" value="1" />
+          <requirement name="IsAlive" target="other" />
+          <requirement name="RandomRoll" seed_type="Random" min_max="0,100" operation="LTE" value="25" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="ModifyCVar" cvar=".stunBatonCharge" operation="add" value="4">
+          <requirement name="ProgressionLevel" progression_name="perkTechJunkie6BatonCharge" operation="Equals" value="1" />
+          <requirement name="IsAlive" target="other" />
+          <requirement name="RandomRoll" seed_type="Random" min_max="0,100" operation="LTE" value="50" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="AddPart" part="Sparks" prefab="ParticleEffects/p_electric_shock_small" parentTransform="Handle" localPos="0,0,0" localRot="0,0,0">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="4" />
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="LT" value="40" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="AddPart" part="Sparks" prefab="ParticleEffects/p_electric_shock_small" parentTransform="Handle" localPos="0,0,0" localRot="0,0,0">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="4" />
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="LT" value="40" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionEnd" action="ModifyCVar" cvar=".stunBatonCharge" operation="set" value="40">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="4" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionEnd" action="ModifyCVar" cvar=".stunBatonCharge" operation="set" value="40">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="4" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="PlaySound" sound="stunbaton_hit1">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="0" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="PlaySound" sound="stunbaton_hit2">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="1" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="PlaySound" sound="stunbaton_hit3">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="2" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="PlaySound" sound="stunbaton_hit4">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="3" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfPrimaryActionRayHit" action="PlaySound" sound="stunbaton_hit5">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="4" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="PlaySound" sound="stunbaton_hit1">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="0" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="PlaySound" sound="stunbaton_hit2">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="1" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="PlaySound" sound="stunbaton_hit3">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="2" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="PlaySound" sound="stunbaton_hit4">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="Equals" value="3" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfSecondaryActionRayHit" action="PlaySound" sound="stunbaton_hit5">
+          <requirement name="CVarCompare" cvar=".stunBatonCharge" operation="GTE" value="4" />
+        </triggered_effect>
+      </effect_group>
+      <effect_group name="meleeWpnBatonT2StunBatonWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeToolSalvageT3ImpactDriverWarden" extends="meleeToolSalvageT3ImpactDriver" material="Mmetal">
-        <effect_group name="meleeToolSalvageT3ImpactDriverWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeWpnBladeT3MacheteWarden" material="Mmetal">
+      <property name="Tags" value="machete,melee,grunting,light,longShaft,perkFlurryOfBlows,weapon,meleeWeapon,attAgility,perkDeepCuts,perkTheHuntsman,canHaveCosmetic" />
+      <property name="DisplayType" value="meleeKnife" />
+      <property name="HoldType" value="47" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Melee/Knives/machetePrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="EconomicValue" value="700" />
+      <property name="SoundJammed" value="ItemNeedsRepair" />
+      <property name="SoundDestroy" value="wooddestroy1" />
+      <property name="Group" value="Ammo/Weapons,Melee Weapons" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <property name="UnlockedBy" value="meleeWpnBladeT3MacheteSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Damage_type" value="Slashing" />
+        <property name="Sphere" value=".15" />
+        <property name="Sound_start" value="machete_swinglight" />
+        <property name="ToolCategory.Butcher" value="0" param1="4.7" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".28" />
+        <property name="GrazeEnd" value=".4" />
+        <property name="SwingDegrees" value="80" />
+        <property name="SwingAngle" value="130" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalslashorganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <property class="Action1">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Damage_type" value="Slashing" />
+        <property name="Sphere" value=".15" />
+        <property name="Sound_start" value="machete_swingheavy" />
+        <property name="ToolCategory.Butcher" value="0" param1="4.7" />
+        <property name="UsePowerAttackAnimation" value="true" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="IsHorizontalSwing" value="true" />
+        <property name="GrazeStart" value=".3" />
+        <property name="GrazeEnd" value=".4" />
+        <property name="SwingDegrees" value="-80" />
+        <property name="SwingAngle" value="-60" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalslashorganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <effect_group name="meleeWpnBladeT3Machete">
+        <passive_effect name="EntityDamage" operation="base_set" value="19.8" tags="perkDeepCuts" />
+        <passive_effect name="BlockDamage" operation="base_set" value="21" tags="perkDeepCuts" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="55" tags="perkDeepCuts,perkFlurryOfBlows" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="19.2" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="288,673" tier="1,6" tags="perkDeepCuts" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkDeepCuts" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.3" tags="perkDeepCuts" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkDeepCuts" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkDeepCuts" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkDeepCuts" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkDeepCuts" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkDeepCuts" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.8" tags="earth" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.8" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.8" tags="metal" />
+        <passive_effect name="HarvestCount" operation="base_set" value="1" tags="butcherHarvest" />
+      </effect_group>
+      <effect_group name="Power Attack">
+        <passive_effect name="EntityDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="32.7" tags="secondary" />
+      </effect_group>
+      <effect_group name="sneak damage bonus">
+        <requirement name="CVarCompare" cvar="_crouching" operation="Equals" value="1" />
+        <requirement name="CVarCompare" cvar="_notAlerted" operation="GT" value="0" target="other" />
+        <passive_effect name="DamageBonus" operation="base_add" value="4" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="4" tags="perkDeepCuts" />
+        <display_value name="dEntityDamageSneak" value="4" />
+      </effect_group>
+      <effect_group name="meleeWpnBladeT3MacheteWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+        <passive_effect name="HarvestCount" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeToolShovelT2SteelShovelWarden" extends="meleeToolShovelT2SteelShovel" material="Mmetal">
-        <effect_group name="meleeToolShovelT2SteelShovelWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeWpnClubT3SteelClubWarden" material="Mmetal">
+      <property name="Tags" value="blunt,club,melee,grunting,light,longShaft,perkFlurryOfBlows,weapon,meleeWeapon,attStrength,perkPummelPete,canHaveCosmetic" />
+      <property name="DisplayType" value="melee" />
+      <property name="Group" value="Ammo/Weapons,Melee Weapons" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Melee/ClubIron/ClubIronPrefab.prefab" />
+      <property name="HoldType" value="2" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="SoundDestroy" value="wooddestroy1" />
+      <property name="RepairExpMultiplier" value="5.5" />
+      <property name="EconomicBundleSize" value="1" />
+      <property name="EconomicValue" value="700" />
+      <property name="UnlockedBy" value="perkBatterUpBaseballBats" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Sound_start" value="batwood_swinglight" />
+        <property name="Sphere" value=".1" />
+        <property name="ToolCategory.harvestingTools" value=".5" param1="1" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".25" />
+        <property name="GrazeEnd" value=".32" />
+        <property name="SwingDegrees" value="65" />
+        <property name="SwingAngle" value="120" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalhitorganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <property class="Action1">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Sound_start" value="batwood_swingheavy" />
+        <property name="Sphere" value=".15" />
+        <property name="ToolCategory.harvestingTools" value=".5" param1="1" />
+        <property name="UsePowerAttackAnimation" value="true" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="IsHorizontalSwing" value="true" />
+        <property name="GrazeStart" value=".25" />
+        <property name="GrazeEnd" value=".32" />
+        <property name="SwingDegrees" value="120" />
+        <property name="SwingAngle" value="90" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="woodhitorganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="woodgrazeorganic" />
+        </property>
+      </property>
+      <effect_group name="meleeWpnClubT3SteelClub">
+        <passive_effect name="EntityDamage" operation="base_set" value="26.2" tags="perkPummelPete" />
+        <passive_effect name="BlockDamage" operation="base_set" value="22.1" tags="perkPummelPete" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="52" tags="perkPummelPete,perkFlurryOfBlows" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="23.7" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="300,700" tier="1,6" tags="perkPummelPete" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkPummelPete" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.4" tags="perkPummelPete" />
+        <passive_effect name="BlockRange" operation="base_set" value="3" tags="perkPummelPete" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkPummelPete" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkPummelPete" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkPummelPete" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkPummelPete" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="earth" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="metal" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allToolsHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="oreWoodHarvest" />
+      </effect_group>
+      <effect_group name="Power Attack">
+        <passive_effect name="EntityDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="40.3" tags="secondary" />
+      </effect_group>
+      <effect_group name="meleeWpnClubT3SteelClubWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeWpnBatonT2StunBatonWarden" extends="meleeWpnBatonT2StunBaton" material="Mmetal">
-        <effect_group name="meleeWpnBatonT2StunBatonWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeWpnKnucklesT3SteelKnucklesWarden" material="Mmetal">
+      <property name="Extends" value="meleeWpnKnucklesT1IronKnuckles" />
+      <property name="Tags" value="blunt,melee,grunting,light,perkFlurryOfBlows,weapon,attFortitude,perkBrawler,canHaveCosmetic" />
+      <property name="Material" value="Mmetal" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Melee/Knuckles/knucklesSpikedRight_Prefab.prefab" />
+      <property name="HoldType" value="79" />
+      <property name="UnlockedBy" value="meleeWpnKnucklesT3SteelKnucklesSchematic" />
+      <property class="Action0">
+        <property name="ToolCategory.Butcher" value="5" param1="1.5" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalstaborganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <property class="Action1">
+        <property name="ToolCategory.Butcher" value="0" param1="1.5" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalstaborganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <effect_group name="meleeWpnKnucklesT3SteelKnuckles">
+        <passive_effect name="EntityDamage" operation="base_set" value="13.6" tags="perkBrawler" />
+        <passive_effect name="BlockDamage" operation="base_set" value="5.2" tags="perkBrawler" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="100" tags="perkBrawler" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="10.2" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="577,1346" tier="1,6" tags="perkBrawler" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkBrawler" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.0" tags="perkBrawler" />
+        <passive_effect name="BlockRange" operation="base_set" value="3" tags="perkBrawler" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkBrawler" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkBrawler" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkBrawler" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkBrawler" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="earth" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.5" tags="metal" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="1.7" tags="organic" />
+        <passive_effect name="HarvestCount" operation="base_set" value="1" tags="butcherHarvest" />
+        <triggered_effect trigger="onSelfEquipStart" action="AddPart" part="LeftKnuckles" prefab="#Other/Items?Weapons/Melee/Knuckles/knucklesSpikedLeft_Prefab.prefab" parentTransform="Propjoint" localPos="0,0,0" localRot="0,0,0">
+          <requirement name="IsFPV" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfEquipStart" action="AddPart" part="LeftKnuckles" prefab="#Other/Items?Weapons/Melee/Knuckles/knucklesSpikedLeft_Prefab.prefab" parentTransform="LeftHand" localPos="-0.1171,0.004,-0.0187" localRot="-30.53241,-11.3179,135.1055">
+          <requirement name="!IsFPV" />
+        </triggered_effect>
+        <triggered_effect trigger="onSelfEquipStop" action="RemovePart" part="LeftKnuckles" />
+      </effect_group>
+      <effect_group name="Power Attack">
+        <passive_effect name="EntityDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="1" tags="secondary" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="-.3" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="17.3" tags="secondary" />
+      </effect_group>
+      <effect_group name="meleeWpnKnucklesT3SteelKnucklesWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeWpnBladeT3MacheteWarden" extends="meleeWpnBladeT3Machete" material="Mmetal">
-        <effect_group name="meleeWpnBladeT3MacheteWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-            <passive_effect name="HarvestCount" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeWpnSledgeT3SteelSledgehammerWarden" material="Mmetal">
+      <property name="Tags" value="blunt,melee,grunting,heavy,sledge,weapon,meleeWeapon,longShaft,attStrength,perkSkullCrusher,canHaveCosmetic" />
+      <property name="DisplayType" value="meleeHeavy" />
+      <property name="HoldType" value="33" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Melee/SledgeHammer/steelSledgeHammerPrefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="RepairTools" value="resourceRepairKit" />
+      <property name="DegradationBreaksAfter" value="false" />
+      <property name="SoundJammed" value="ItemNeedsRepair" />
+      <property name="SoundDestroy" value="metaldestroy1" />
+      <property name="EconomicValue" value="700" />
+      <property name="Group" value="Ammo/Weapons,Melee Weapons" />
+      <property name="UnlockedBy" value="meleeWpnSledgeT3SteelSledgehammerSchematic" />
+      <property name="ShowQuality" value="true" />
+      <property class="Action0">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Sphere" value=".15" />
+        <property name="Sound_start" value="sledge_swinglight" />
+        <property name="ToolCategory.harvestingTools" value=".5" param1="1" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".515" />
+        <property name="GrazeEnd" value=".52" />
+        <property name="SwingDegrees" value="65" />
+        <property name="SwingAngle" value="160" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalsolidhitorganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <property class="Action1">
+        <property name="Class" value="DynamicMelee" />
+        <property name="Sphere" value=".15" />
+        <property name="Sound_start" value="sledge_swingheavy" />
+        <property name="ToolCategory.harvestingTools" value=".5" param1="1" />
+        <property name="UsePowerAttackAnimation" value="true" />
+        <property name="UseGrazingHits" value="true" />
+        <property name="GrazeStart" value=".515" />
+        <property name="GrazeEnd" value=".52" />
+        <property name="SwingDegrees" value="110" />
+        <property name="SwingAngle" value="90" />
+        <property class="HitSounds">
+          <property name="Override0" value="organic" param1="metalsolidhitorganic" />
+        </property>
+        <property class="GrazeSounds">
+          <property name="Override0" value="organic" param1="metalgrazeorganic" />
+        </property>
+      </property>
+      <effect_group name="meleeWpnSledgeT3SteelSledgehammer">
+        <passive_effect name="EntityDamage" operation="base_set" value="46.2" tags="perkSkullCrusher" />
+        <passive_effect name="BlockDamage" operation="base_set" value="85" tags="perkSkullCrusher" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="34" tags="perkSkullCrusher" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="40.5" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="207,581" tier="1,6" tags="perkSkullCrusher" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkSkullCrusher" />
+        <passive_effect name="MaxRange" operation="base_set" value="2.6" tags="perkSkullCrusher" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkSkullCrusher" />
+        <passive_effect name="DismemberChance" operation="base_add" value=".1" tags="perkSkullCrusher,primary" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkSkullCrusher" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkSkullCrusher" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkSkullCrusher" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkSkullCrusher" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allToolsHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="oreWoodHarvest" />
+      </effect_group>
+      <effect_group name="Power Attack">
+        <passive_effect name="EntityDamage" operation="perc_add" value="1.25" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="1.25" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="81" tags="secondary" />
+        <passive_effect name="DismemberChance" operation="base_add" value=".3" tags="secondary" />
+      </effect_group>
+      <effect_group name="meleeWpnSledgeT3SteelSledgehammerWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeWpnClubT3SteelClubWarden" extends="meleeWpnClubT3SteelClub" material="Mmetal">
-        <effect_group name="meleeWpnClubT3SteelClubWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
+    <item name="meleeWpnSpearT3SteelSpearWarden" material="Mmetal">
+      <property name="Extends" value="meleeWpnSpearT1IronSpear" />
+      <property name="Meshfile" value="#Other/Items?Weapons/Melee/Spear/spear_steel_Prefab.prefab" />
+      <property name="Material" value="Mmetal" />
+      <property name="Weight" value="6" />
+      <property name="StickyMaterial" value="#Other/Items?Weapons/Melee/Spear/Materials/spearIron_sticky.mat" />
+      <property name="EconomicValue" value="700" />
+      <property name="UnlockedBy" value="perkSpearHunter3SteelSpears" />
+      <property class="Action1">
+        <requirement name="StatCompareCurrent" stat="Stamina" operation="GTE" value="22.8" />
+      </property>
+      <effect_group name="meleeWpnSpearT3SteelSpear">
+        <passive_effect name="EntityDamage" operation="base_set" value="18.6" tags="perkJavelinMaster" />
+        <passive_effect name="TargetArmor" operation="perc_add" value="-.5" tags="perkJavelinMaster" />
+        <display_value name="dTargetArmor" value="-.5" />
+        <passive_effect name="BlockDamage" operation="base_set" value="9" tags="perkJavelinMaster" />
+        <passive_effect name="AttacksPerMinute" operation="base_set" value="55" tags="perkJavelinMaster" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="22.4" tags="primary" />
+        <passive_effect name="DegradationMax" operation="base_set" value="317,592" tier="1,6" tags="perkJavelinMaster" />
+        <passive_effect name="DegradationPerUse" operation="base_set" value="1" tags="perkJavelinMaster" />
+        <passive_effect name="MaxRange" operation="base_set" value="3.2" tags="perkJavelinMaster" />
+        <passive_effect name="BlockRange" operation="base_set" value="3.5" tags="perkJavelinMaster" />
+        <passive_effect name="ModSlots" operation="base_set" value="1,1,2,2,3,4" tier="1,2,3,4,5,6" />
+        <passive_effect name="ModPowerBonus" operation="perc_add" value=".10" tags="EntityDamage,BlockDamage" />
+        <passive_effect name="ModPowerBonus" operation="base_add" value="300" tags="EconomicValue" />
+        <passive_effect name="EntityDamage" operation="perc_add" value="-.15,.15" tags="perkJavelinMaster" />
+        <passive_effect name="EntityDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkJavelinMaster" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="-.15,.15" tags="perkJavelinMaster" />
+        <passive_effect name="BlockDamage" operation="perc_add" value=".1,.5" tier="2,6" tags="perkJavelinMaster" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.8" tags="wood" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.9" tags="stone" />
+        <passive_effect name="DamageModifier" operation="perc_add" value="-.9" tags="metal" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="allToolsHarvest" />
+        <passive_effect name="HarvestCount" operation="base_add" value="-.75" tags="oreWoodHarvest" />
+      </effect_group>
+      <effect_group name="Throw">
+        <passive_effect name="EntityDamage" operation="perc_add" value="2.85" tags="secondary" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="2.85" tags="secondary" />
+        <passive_effect name="StaminaLoss" operation="base_set" value="44.8" tags="secondary" />
+      </effect_group>
+      <property name="Group" value="Ammo/Weapons,Melee Weapons,Ranged Weapons" />
+      <effect_group name="meleeWpnSpearT3SteelSpearWarden">
+        <passive_effect name="EntityDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="BlockDamage" operation="perc_add" value="0.5" />
+        <passive_effect name="DegradationMax" operation="perc_add" value="0.5" />
+        <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5" />
+      </effect_group>
+      <property name="ModSlots" value="6" />
+      <property name="CreativeMode" value="Player" />
+      <property name="CustomIconTint" value="FFD700" />
     </item>
-    <item name="meleeWpnKnucklesT3SteelKnucklesWarden" extends="meleeWpnKnucklesT3SteelKnuckles" material="Mmetal">
-        <effect_group name="meleeWpnKnucklesT3SteelKnucklesWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
-    </item>
-    <item name="meleeWpnSledgeT3SteelSledgehammerWarden" extends="meleeWpnSledgeT3SteelSledgehammer" material="Mmetal">
-        <effect_group name="meleeWpnSledgeT3SteelSledgehammerWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
-    </item>
-    <item name="meleeWpnSpearT3SteelSpearWarden" extends="meleeWpnSpearT3SteelSpear" material="Mmetal">
-        <effect_group name="meleeWpnSpearT3SteelSpearWarden">
-            <passive_effect name="EntityDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="BlockDamage" operation="perc_add" value="0.5"/>
-            <passive_effect name="DegradationMax" operation="perc_add" value="0.5"/>
-            <passive_effect name="AttacksPerMinute" operation="perc_add" value="0.5"/>
-        </effect_group>
-        <property name="ModSlots" value="6"/>
-        <property name="CreativeMode" value="Player"/>
-        <property name="CustomIconTint" value="FFD700"/>
-    </item>
-    </append>
+  </append>
 </configs>


### PR DESCRIPTION
## Summary
- Inline full property sets from original items.xml into each Warden item
- Keep Warden-specific bonus effect groups and cosmetic settings

## Testing
- `xmllint --noout Config/items.xml`


------
https://chatgpt.com/codex/tasks/task_e_6891b1a7977c83268bbb218b57818bf1