### PR TITLE
Remove zoom effect from Warden nailgun

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -1089,7 +1089,6 @@
         <passive_effect name="SpreadDegreesVertical" operation="base_set" value=".3" />
         <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value=".3" />
         <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="0.5" />
-        <passive_effect name="ZoomFOV" operation="base_set" value="45" />
         <passive_effect name="AimDuration" operation="base_set" value="0.1" />
         <passive_effect name="SpreadMultiplierAiming" operation="base_set" value="0.3" />
       </effect_group>


### PR DESCRIPTION
## Summary
- eliminate zoom effect from Warden Nailgun by removing ZoomFOV passive effect

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891b4fccbf48326b6c0f72eade99423