### PR TITLE
Remove aim duration from Warden nailgun

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -1089,7 +1089,6 @@
         <passive_effect name="SpreadDegreesVertical" operation="base_set" value=".3" />
         <passive_effect name="SpreadDegreesHorizontal" operation="base_set" value=".3" />
         <passive_effect name="IncrementalSpreadMultiplier" operation="base_set" value="0.5" />
-        <passive_effect name="AimDuration" operation="base_set" value="0.1" />
         <passive_effect name="SpreadMultiplierAiming" operation="base_set" value="0.3" />
       </effect_group>
       <property name="DisplayName" value="Warden Nailgun" />


### PR DESCRIPTION
## Summary
- remove `AimDuration` from Warden nailgun to eliminate aiming delay

## Testing
- `xmllint --noout Config/items.xml`
- `xmllint --noout items.xml`


------
https://chatgpt.com/codex/tasks/task_e_6891b7def4c483268f0d6099be96ec7c