### PR TITLE
Enable creative mode for Warden Nailgun

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -1093,7 +1093,7 @@
         <passive_effect name="SpreadMultiplierAiming" operation="base_set" value="0.3" />
       </effect_group>
       <property name="DisplayName" value="Warden Nailgun" />
-      <property name="CreativeMode" value="None" />
+      <property name="CreativeMode" value="Player" />
       <property name="CustomIconTint" value="FFD700" />
       <property name="EconomicValue" value="5000" />
       <property name="ShowQuality" value="true" />


### PR DESCRIPTION
## Summary
- allow the Warden Nailgun item in creative mode

## Testing
- `xmllint Config/items.xml --noout`


------
https://chatgpt.com/codex/tasks/task_e_6891b8507c408326aaa5b5be9905cf16