### PR TITLE
refactor: simplify stack config syntax

### DIFF
--- a/WardenStacks/Config/wardenStacks.xml
+++ b/WardenStacks/Config/wardenStacks.xml
@@ -1,87 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configs>
-    <set xpath="/items/item[@name='ammo762mmBulletBall']/property[@name='Stacknumber']/@value" value="300"/>
-    <set xpath="/items/item[@name='ammo9mmBulletBall']/property[@name='Stacknumber']/@value" value="600"/>
-    <set xpath="/items/item[@name='ammoArrowExploding']/property[@name='Stacknumber']/@value" value="150"/>
-    <set xpath="/items/item[@name='ammoArrowStone']/property[@name='Stacknumber']/@value" value="300"/>
-    <set xpath="/items/item[@name='ammoCrossbowBoltExploding']/property[@name='Stacknumber']/@value" value="150"/>
-    <set xpath="/items/item[@name='ammoCrossbowBoltIron']/property[@name='Stacknumber']/@value" value="300"/>
-    <set xpath="/items/item[@name='ammoCrossbowBoltStone']/property[@name='Stacknumber']/@value" value="300"/>
-    <set xpath="/items/item[@name='ammoDartIron']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='ammoGasCan']/property[@name='Stacknumber']/@value" value="20000"/>
-    <set xpath="/items/item[@name='ammoJunkTurretRegular']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='ammoRocketHE']/property[@name='Stacknumber']/@value" value="40"/>
-    <set xpath="/items/item[@name='ammoShotgunBreachingSlug']/property[@name='Stacknumber']/@value" value="300"/>
-    <set xpath="/items/item[@name='ammoShotgunShell']/property[@name='Stacknumber']/@value" value="300"/>
-    <set xpath="/items/item[@name='ammoShotgunSlug']/property[@name='Stacknumber']/@value" value="300"/>
-    <set xpath="/items/item[@name='resourceAcid']/property[@name='Stacknumber']/@value" value="200"/>
-    <set xpath="/items/item[@name='resourceAirFilter']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceAnimalFat']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceArrowHeadIron']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceArrowHeadSteelAP']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceBone']/property[@name='Stacknumber']/@value" value="2400"/>
-    <set xpath="/items/item[@name='resourceBrokenGlass']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceBuckshot']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceBulletCasing']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceBulletTip']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceCandleStick']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceCandyTin']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceCement']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceClayLump']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceCloth']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceCoal']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceCobblestones']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceConcreteMix']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceCropAloeLeaf']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceCropChrysanthemumPlant']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceCropCoffeeBeans']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceCropCottonPlant']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceCropGoldenrodPlant']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceCropHopsFlower']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceCrushedSand']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceDoorKnob']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceDuctTape']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceElectricParts']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceElectronicParts']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceFeather']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceFishingWeight']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceForgedIron']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceForgedSteel']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceGlue']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceGunPowder']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceHeadlight']/property[@name='Stacknumber']/@value" value="100"/>
-    <set xpath="/items/item[@name='resourceHubcap']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceIronFragment']/property[@name='Stacknumber']/@value" value="2400"/>
-    <set xpath="/items/item[@name='resourceLeather']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceLockPick']/property[@name='Stacknumber']/@value" value="100"/>
-    <set xpath="/items/item[@name='resourceLockPickBundle']/property[@name='Stacknumber']/@value" value="10"/>
-    <set xpath="/items/item[@name='resourceMechanicalParts']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceMetalPipe']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceMilitaryFiber']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceNail']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceOil']/property[@name='Stacknumber']/@value" value="100"/>
-    <set xpath="/items/item[@name='resourceOilShale']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourcePaint']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourcePaper']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourcePotassiumNitratePowder']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceRadiator']/property[@name='Stacknumber']/@value" value="10"/>
-    <set xpath="/items/item[@name='resourceRepairKit']/property[@name='Stacknumber']/@value" value="50"/>
-    <set xpath="/items/item[@name='resourceRockSmall']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceRockSmallBundle']/property[@name='Stacknumber']/@value" value="10"/>
-    <set xpath="/items/item[@name='resourceRocketCasing']/property[@name='Stacknumber']/@value" value="100"/>
-    <set xpath="/items/item[@name='resourceRocketTip']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceScrapBrass']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceScrapIron']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceScrapLead']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceScrapPolymers']/property[@name='Stacknumber']/@value" value="2000"/>
-    <set xpath="/items/item[@name='resourceSewingKit']/property[@name='Stacknumber']/@value" value="40"/>
-    <set xpath="/items/item[@name='resourceSilverNugget']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceSnowBall']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceSpring']/property[@name='Stacknumber']/@value" value="1000"/>
-    <set xpath="/items/item[@name='resourceTestosteroneExtract']/property[@name='Stacknumber']/@value" value="20"/>
-    <set xpath="/items/item[@name='resourceTrophy1']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceTrophy2']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceTrophy3']/property[@name='Stacknumber']/@value" value="500"/>
-    <set xpath="/items/item[@name='resourceWood']/property[@name='Stacknumber']/@value" value="12000"/>
-    <set xpath="/items/item[@name='resourceYuccaFibers']/property[@name='Stacknumber']/@value" value="12000"/>
+    <set xpath="/items/item[@name='ammo762mmBulletBall']/property[@name='Stacknumber']/@value">300</set>
+    <set xpath="/items/item[@name='ammo9mmBulletBall']/property[@name='Stacknumber']/@value">600</set>
+    <set xpath="/items/item[@name='ammoArrowExploding']/property[@name='Stacknumber']/@value">150</set>
+    <set xpath="/items/item[@name='ammoArrowStone']/property[@name='Stacknumber']/@value">300</set>
+    <set xpath="/items/item[@name='ammoCrossbowBoltExploding']/property[@name='Stacknumber']/@value">150</set>
+    <set xpath="/items/item[@name='ammoCrossbowBoltIron']/property[@name='Stacknumber']/@value">300</set>
+    <set xpath="/items/item[@name='ammoCrossbowBoltStone']/property[@name='Stacknumber']/@value">300</set>
+    <set xpath="/items/item[@name='ammoDartIron']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='ammoGasCan']/property[@name='Stacknumber']/@value">20000</set>
+    <set xpath="/items/item[@name='ammoJunkTurretRegular']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='ammoRocketHE']/property[@name='Stacknumber']/@value">40</set>
+    <set xpath="/items/item[@name='ammoShotgunBreachingSlug']/property[@name='Stacknumber']/@value">300</set>
+    <set xpath="/items/item[@name='ammoShotgunShell']/property[@name='Stacknumber']/@value">300</set>
+    <set xpath="/items/item[@name='ammoShotgunSlug']/property[@name='Stacknumber']/@value">300</set>
+    <set xpath="/items/item[@name='resourceAcid']/property[@name='Stacknumber']/@value">200</set>
+    <set xpath="/items/item[@name='resourceAirFilter']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceAnimalFat']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceArrowHeadIron']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceArrowHeadSteelAP']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceBone']/property[@name='Stacknumber']/@value">2400</set>
+    <set xpath="/items/item[@name='resourceBrokenGlass']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceBuckshot']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceBulletCasing']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceBulletTip']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceCandleStick']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceCandyTin']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceCement']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceClayLump']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceCloth']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceCoal']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceCobblestones']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceConcreteMix']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceCropAloeLeaf']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceCropChrysanthemumPlant']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceCropCoffeeBeans']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceCropCottonPlant']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceCropGoldenrodPlant']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceCropHopsFlower']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceCrushedSand']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceDoorKnob']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceDuctTape']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceElectricParts']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceElectronicParts']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceFeather']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceFishingWeight']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceForgedIron']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceForgedSteel']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceGlue']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceGunPowder']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceHeadlight']/property[@name='Stacknumber']/@value">100</set>
+    <set xpath="/items/item[@name='resourceHubcap']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceIronFragment']/property[@name='Stacknumber']/@value">2400</set>
+    <set xpath="/items/item[@name='resourceLeather']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceLockPick']/property[@name='Stacknumber']/@value">100</set>
+    <set xpath="/items/item[@name='resourceLockPickBundle']/property[@name='Stacknumber']/@value">10</set>
+    <set xpath="/items/item[@name='resourceMechanicalParts']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceMetalPipe']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceMilitaryFiber']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceNail']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceOil']/property[@name='Stacknumber']/@value">100</set>
+    <set xpath="/items/item[@name='resourceOilShale']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourcePaint']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourcePaper']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourcePotassiumNitratePowder']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceRadiator']/property[@name='Stacknumber']/@value">10</set>
+    <set xpath="/items/item[@name='resourceRepairKit']/property[@name='Stacknumber']/@value">50</set>
+    <set xpath="/items/item[@name='resourceRockSmall']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceRockSmallBundle']/property[@name='Stacknumber']/@value">10</set>
+    <set xpath="/items/item[@name='resourceRocketCasing']/property[@name='Stacknumber']/@value">100</set>
+    <set xpath="/items/item[@name='resourceRocketTip']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceScrapBrass']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceScrapIron']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceScrapLead']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceScrapPolymers']/property[@name='Stacknumber']/@value">2000</set>
+    <set xpath="/items/item[@name='resourceSewingKit']/property[@name='Stacknumber']/@value">40</set>
+    <set xpath="/items/item[@name='resourceSilverNugget']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceSnowBall']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceSpring']/property[@name='Stacknumber']/@value">1000</set>
+    <set xpath="/items/item[@name='resourceTestosteroneExtract']/property[@name='Stacknumber']/@value">20</set>
+    <set xpath="/items/item[@name='resourceTrophy1']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceTrophy2']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceTrophy3']/property[@name='Stacknumber']/@value">500</set>
+    <set xpath="/items/item[@name='resourceWood']/property[@name='Stacknumber']/@value">12000</set>
+    <set xpath="/items/item[@name='resourceYuccaFibers']/property[@name='Stacknumber']/@value">12000</set>
 </configs>


### PR DESCRIPTION
## Summary
- use element body instead of `value` attribute for stack sizes in `wardenStacks.xml`

## Testing
- `xmllint --noout WardenStacks/Config/wardenStacks.xml`


------
https://chatgpt.com/codex/tasks/task_e_68927997656c8326a7523b06dd864e40